### PR TITLE
Use debugme

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,12 +25,14 @@ Imports:
     R6,
     stringi,
     websocket
+Suggests: 
+    debugme
 Remotes:
     rstudio/websocket
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 Collate: 
     'send.R'
     'Accessibility_commands.R'
@@ -105,3 +107,4 @@ Collate:
     'chr_connect.R'
     'utils-pipe.R'
     'wait.R'
+    'zzz.R'

--- a/R/chr_connect.R
+++ b/R/chr_connect.R
@@ -294,11 +294,12 @@ chr_close <- function(chr_process, work_dir) {
   if (!killed) {
     "!DEBUG Closing headless Chrome..."
     chr_process$kill()
-    if (chr_process$is_alive())
+    if (chr_process$is_alive()) {
       "!DEBUG Cannot close headless Chrome."
       stop("Cannot close headless Chrome.\n")
-    else
+    } else {
       "!DEBUG ...headless Chrome closed."
+    }
   }
 
   cleaned <- later::later(~chr_clean_work_dir(work_dir), 0.2)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,3 @@
+.onLoad <- function(libname, pkgname) {
+  if(requireNamespace("debugme", quietly = TRUE)) debugme::debugme()
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,11 @@
 .onLoad <- function(libname, pkgname) {
-  if(requireNamespace("debugme", quietly = TRUE)) debugme::debugme()
+  if(requireNamespace("debugme", quietly = TRUE)) {
+    debugme::debugme()
+  } else {
+    if ("crrri" %in% strsplit(Sys.getenv("DEBUGME"), split = ",")[[1]]) {
+      message("It seems you have this package in your DEBUGME variable,",
+              "but you have not install the debugme package yet.\n",
+              "You need to install it to the the log messages.")
+    }
+  }
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -187,7 +187,6 @@ You can find many other examples in the [wiki](https://github.com/cyrus-and/chro
 
 ### Logging Messages
 
-
 In `crrri`, there are two types of messages: 
 
 - Those sent during connexion/deconnexion (mainly for crrri debugging) 
@@ -202,7 +201,8 @@ information on what is going on.
 
 You need to add `"crrri"` to the `DEBUGME` environment variable before loading
 the package to activate the messaging feature. Currently in `crrri` there is
-only one level of message. 
+only one level of message.Also, `debugme` is a Suggested dependency and you may
+need to install it manually if not already installed.
 
 ## Credits
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -183,6 +183,27 @@ dumpDOM(url = "http://www.ardata.fr/blog/")
 
 You can find many other examples in the [wiki](https://github.com/cyrus-and/chrome-remote-interface/wiki) of the `chrome-remote-interface` module.
 
+## Development
+
+### Logging Messages
+
+
+In `crrri`, there are two types of messages: 
+
+- Those sent during connexion/deconnexion (mainly for crrri debugging) 
+- Those tracking the exchanges between the R websocket client and the remote
+websocket server. These lasts are essential for R devs to develop higher levels
+packages, either during the development process and for debugging purposes.
+
+`crrri` uses [`debugme`](https://github.com/r-lib/debugme) for printing those
+messages. It is disable by default and you won't see any messages - as a user we
+think it is fine. However, if you are a developer, you would expect some
+information on what is going on.
+
+You need to add `"crrri"` to the `DEBUGME` environment variable before loading
+the package to activate the messaging feature. Currently in `crrri` there is
+only one level of message. 
+
 ## Credits
 
 Miles McBain for `chradle`.

--- a/README.md
+++ b/README.md
@@ -237,7 +237,9 @@ would expect some information on what is going on.
 
 You need to add `"crrri"` to the `DEBUGME` environment variable before
 loading the package to activate the messaging feature. Currently in
-`crrri` there is only one level of message.
+`crrri` there is only one level of message.Also, `debugme` is a
+Suggested dependency and you may need to install it manually if not
+already installed.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,27 @@ You can find many other examples in the
 [wiki](https://github.com/cyrus-and/chrome-remote-interface/wiki) of the
 `chrome-remote-interface` module.
 
+## Development
+
+### Logging Messages
+
+In `crrri`, there are two types of messages:
+
+  - Those sent during connexion/deconnexion (mainly for crrri debugging)
+  - Those tracking the exchanges between the R websocket client and the
+    remote websocket server. These lasts are essential for R devs to
+    develop higher levels packages, either during the development
+    process and for debugging purposes.
+
+`crrri` uses [`debugme`](https://github.com/r-lib/debugme) for printing
+those messages. It is disable by default and you won’t see any messages
+- as a user we think it is fine. However, if you are a developer, you
+would expect some information on what is going on.
+
+You need to add `"crrri"` to the `DEBUGME` environment variable before
+loading the package to activate the messaging feature. Currently in
+`crrri` there is only one level of message.
+
 ## Credits
 
 Miles McBain for `chradle`.


### PR DESCRIPTION
this closes #10 using `debugme` to replace all `cat` message with the meachism from debugme. 

To activate it, 

* `Sys.setenv(DEBUGME="crrri")` in session
* add `DEBUGME="crrrri"` to `.Renviron` (`usethis::edit_r_environ()`)

Debug can be used for several package. For example, 

`DEBUGME="crrrri,processx"` will also print debug for processx 📦

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rlesur/crrri/13)
<!-- Reviewable:end -->
