### PR TITLE
add some function for CDP session control

### DIFF
--- a/R/DevToolsConnexion.R
+++ b/R/DevToolsConnexion.R
@@ -133,6 +133,12 @@ CDPSession <- R6::R6Class(
     once = function(eventName, callback) {
       super$once(eventName, callback)
       invisible(self)
+    },
+    readyState = function() {
+      private$.CDPSession_con$readyState()
+    },
+    close = function() {
+      private$.CDPSession_con$close()
     }
   ),
   active = list(

--- a/tests/manual/manual_test_CDPSession.R
+++ b/tests/manual/manual_test_CDPSession.R
@@ -9,7 +9,7 @@ ws_endpoint <- chr_get_ws_addr(debug_port = 9222)
 page_session <- CDPSession$new(ws_endpoint)
 
 # page_session is in pre-connecting test until connection is explicitely launch
-page_session$.__enclos_env__$private$.CDPSession_con$readyState()
+page_session$readyState()
 
 # listening event
 page_session$once("Runtime.executionContextCreated", function(...) cat("First command passed!"))
@@ -54,7 +54,7 @@ page_session$
 page_session$connect()
 
 # closing the session and chrome
-page_session$.__enclos_env__$private$.CDPSession_con$close()
+page_session$close()
 if(chrome$is_alive()) chrome$kill()
 rm(list = ls())
 gc()

--- a/tests/manual/manual_test_CDPSession.R
+++ b/tests/manual/manual_test_CDPSession.R
@@ -72,7 +72,7 @@ ws_endpoint <- chr_get_ws_addr(debug_port = 9222)
 page_session <- CDPSession$new(ws_endpoint)
 
 # page_session is in pre-connecting test until connection is explicitely launch
-page_session$.__enclos_env__$private$.CDPSession_con$readyState()
+page_session$readyState()
 
 # listening event
 page_session$once("Runtime.executionContextCreated", function(...) cat("First command passed!"))
@@ -125,7 +125,7 @@ page_session$once("Page.printToPDF",
 page_session$connect()
 
 # closing the session and chrome
-page_session$.__enclos_env__$private$.CDPSession_con$close()
+page_session$close()
 if(chrome$is_alive()) chrome$kill()
 rm(list = ls())
 gc()


### PR DESCRIPTION
Based on the example, I just added

* `readyState()` to have the state of the websocket connection
* `close()` to close the connection

Do you find them useful ? 
Do you have others functions in mind that are missing ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rlesur/crrri/39)
<!-- Reviewable:end -->
