### PR TITLE
Remove later::run_now in CDPSession disconnect method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,8 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1
 VignetteBuilder: knitr
 Collate: 
+    'wait.R'
+    'hold.R'
     'utils.R'
     'CDProtocol.R'
     'utils-pipe.R'
@@ -51,6 +53,4 @@ Collate:
     'CDPSession.R'
     'CDPRemote.R'
     'Chrome.R'
-    'wait.R'
-    'hold.R'
     'zzz.R'

--- a/R/CDPSession.R
+++ b/R/CDPSession.R
@@ -265,7 +265,7 @@ CDPConnexion <- R6::R6Class(
       if(self$readyState() == 3L) {
         if(!is.null(callback)) {
           on.exit(do.call(callback, list(self)), add = TRUE)
-          return(self)
+          return(invisible(self))
         } else {
           return(promises::promise_resolve(self))
         }

--- a/R/CDPSession.R
+++ b/R/CDPSession.R
@@ -134,7 +134,7 @@ CDPConnexion <- R6::R6Class(
         private$.ready <- FALSE
       })
       super$once("connect", function(client) {
-        self$emit("ready", NULL)
+        self$emit("ready")
       })
       rm_onerror <- NULL
       rm_onconnect <- NULL

--- a/R/hold.R
+++ b/R/hold.R
@@ -15,7 +15,8 @@ NULL
 #'
 #' @param x A [promises::promise()] object.
 #' @param timeout Number scalar, timeout in seconds. An error is thrown if the
-#'   promise is still pending when the timeout expires.
+#'   promise is still pending when the delay expires.
+#' @param msg Error message when the timeout expires.
 #'
 #' @return The value of the promise once resolved.
 #' @export
@@ -30,12 +31,12 @@ NULL
 #' value <- hold(pr)
 #' cat(value, "\n")
 #' }
-hold <- function(x, timeout = 30) {
+hold <- function(x, timeout = 30, msg = paste("The asynchronous job has not finished in the delay of", timeout, "seconds.")) {
   x <- promises::as.promise(x)
   assert_that(is.number(timeout))
   promise <- promises::promise_race(
     x,
-    timeout(delay = timeout)
+    timeout(delay = timeout, msg = msg)
   )
 
   state <- new.env()

--- a/R/wait.R
+++ b/R/wait.R
@@ -33,11 +33,12 @@ wait <- function(promise, delay = 0) {promises::then(
 #' Set a timeout
 #'
 #' @param delay Number of seconds before rejecting the promise.
+#' @param msg Message if the timeout expires.
 #'
 #' @return A promise that if rejected after a delay of `delay` seconds.
 #' @export
-timeout <- function(delay = 0) {
+timeout <- function(delay = 0, msg = paste("The delay of", delay, "seconds expired.\n")) {
   promises::promise(function(resolve, reject) {
-    later::later(~ reject(paste("The delay of", delay, "seconds expired.\n")), delay)
+    later::later(~ reject(simpleError(msg)), delay)
   })
 }

--- a/man/CDPRemote.Rd
+++ b/man/CDPRemote.Rd
@@ -13,7 +13,7 @@ Protocol. It possesses methods to manage connections.
 
 remote$connect(callback = NULL)
 remote$listConnections()
-remote$closeConnections()
+remote$closeConnections(callback = NULL)
 remote$version()
 remote$user_agent
 }
@@ -56,7 +56,8 @@ this promise is the connection object.
 created using the \code{$connect()} method.
 
 \code{$closeConnections()} closes all the connections created using the
-\code{$connect()} method.
+\code{$connect()} method. Returns a promise which is resolved when all connections
+are closed.
 
 \code{$version()} executes the DevTools \code{Version} method. It returns a list of
 informations available at \code{http://<host>:<debug_port>/json/version}.

--- a/man/Chrome.Rd
+++ b/man/Chrome.Rd
@@ -65,8 +65,9 @@ object.
 \code{$listConnections()} returns a list of the connection objects succesfully
 created using the \code{$connect()} method.
 
-\code{$closeConnections()} closes all the connections created using the
-\code{$connect()} method.
+\code{$closeConnections(callback = NULL)} closes all the connections created using the
+\code{$connect()} method. Returns a promise which is resolved when all connections
+are closed.
 
 \code{$version()} executes the DevTools \code{Version} method. It returns a list of
 informations available at \code{http://localhost:<debug_port>/json/version}.

--- a/man/hold.Rd
+++ b/man/hold.Rd
@@ -4,13 +4,17 @@
 \alias{hold}
 \title{Hold while an asynchronous task runs}
 \usage{
-hold(x, timeout = 30)
+hold(x, timeout = 30,
+  msg = paste("The asynchronous job has not finished in the delay of",
+  timeout, "seconds."))
 }
 \arguments{
 \item{x}{A \code{\link[promises:promise]{promises::promise()}} object.}
 
 \item{timeout}{Number scalar, timeout in seconds. An error is thrown if the
-promise is still pending when the timeout expires.}
+promise is still pending when the delay expires.}
+
+\item{msg}{Error message when the timeout expires.}
 }
 \value{
 The value of the promise once resolved.

--- a/man/timeout.Rd
+++ b/man/timeout.Rd
@@ -4,10 +4,13 @@
 \alias{timeout}
 \title{Set a timeout}
 \usage{
-timeout(delay = 0)
+timeout(delay = 0, msg = paste("The delay of", delay,
+  "seconds expired.\\n"))
 }
 \arguments{
 \item{delay}{Number of seconds before rejecting the promise.}
+
+\item{msg}{Message if the timeout expires.}
 }
 \value{
 A promise that if rejected after a delay of \code{delay} seconds.

--- a/tests/testthat/test-cdpsession.R
+++ b/tests/testthat/test-cdpsession.R
@@ -1,0 +1,20 @@
+context("test-cdpsession")
+
+chrome <- Chrome$new()
+
+test_that("connect and disconnect methods return promises", {
+  client_pr <- CDPSession()
+  expect_is(client_pr, "promise")
+  client <- hold(client_pr)
+  expect_is(client, "CDPSession")
+  closed_pr <- client$disconnect()
+  expect_is(closed_pr, "promise")
+  hold(closed_pr)
+})
+
+test_that("CDPSession is disconnected when removed", {
+  client <- hold(CDPSession())
+  expect_message(client$.__enclos_env__$private$finalize())
+})
+
+chrome$close()

--- a/tests/testthat/test-chrome.R
+++ b/tests/testthat/test-chrome.R
@@ -2,6 +2,14 @@ context("test-chrome")
 
 chrome <- Chrome$new()
 
+test_that("is_alive() returns a logical", {
+  expect_is(chrome$is_alive(), "logical")
+})
+
+test_that("Chrome cannot be launched if the port is already used", {
+  expect_error(Chrome$new())
+})
+
 test_that("Chrome$new() returns a Chrome class object", {
   expect_is(chrome, "Chrome")
   expect_is(chrome, "CDPRemote")
@@ -20,4 +28,13 @@ test_that("connect() returns a CDPSession object that is closed with closeConnec
   expect_equivalent(client$readyState(), 3L)
 })
 
-chrome$close()
+test_that("close() returns the Chrome object", {
+  closed <- chrome$close()
+  expect_reference(closed, chrome)
+})
+
+test_that("once closed, is_alive() return FALSE", {
+  expect_identical(chrome$is_alive(), FALSE)
+})
+
+

--- a/tests/testthat/test-chrome.R
+++ b/tests/testthat/test-chrome.R
@@ -8,4 +8,16 @@ test_that("Chrome$new() returns a Chrome class object", {
   expect_is(chrome, "R6")
 })
 
+test_that("connect() returns a CDPSession object that is closed with closeConnections()", {
+  client_pr <- chrome$connect()
+  expect_is(client_pr, "promise")
+  client <- hold(client_pr)
+  expect_is(client, "CDPSession")
+  closed_pr <- chrome$closeConnections()
+  expect_is(closed_pr, "promise")
+  closed_pr_value <- hold(closed_pr)
+  expect_reference(closed_pr_value, chrome)
+  expect_equivalent(client$readyState(), 3L)
+})
+
 chrome$close()


### PR DESCRIPTION
This PR closes #47 .
There were many side effects on `closeConnections()` and `finalize()` methods for `CDPRemote` and `Chrome` classes.