### PR TITLE
add a skip function for testthat if chrome is not available

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,7 +1,4 @@
 library(testthat)
 library(crrri)
 
-not_chrome <- !nzchar(Sys.getenv("HEADLESS_CHROME"))
-filter <- if(not_chrome) "^((?!needs-chrome).)*$"
-
-test_check("crrri", filter = filter, perl = TRUE)
+test_check("crrri")

--- a/tests/testthat/helpers-chrome.R
+++ b/tests/testthat/helpers-chrome.R
@@ -1,0 +1,6 @@
+skip_if_not_chrome <- function() {
+  if (nzchar(Sys.getenv("HEADLESS_CHROME"))) {
+    return(invisible(TRUE))
+  }
+  testthat::skip("Chrome is required to run this tests\nand is not available in the current testing environment.")
+}

--- a/tests/testthat/test-cdpsession.R
+++ b/tests/testthat/test-cdpsession.R
@@ -1,5 +1,7 @@
 context("test-cdpsession")
 
+skip_if_not_chrome()
+
 chrome <- Chrome$new()
 
 test_that("connect and disconnect methods return promises", {

--- a/tests/testthat/test-chrome.R
+++ b/tests/testthat/test-chrome.R
@@ -1,5 +1,7 @@
 context("test-chrome")
 
+skip_if_not_chrome()
+
 chrome <- Chrome$new()
 
 test_that("is_alive() returns a logical", {


### PR DESCRIPTION
This is a new suggestion for https://github.com/RLesur/crrri/issues/45#issuecomment-486852362 adjustments regarding chrome not being available in the testing environment.  

This is closer to the testthat way of doing this things. I don't like having to modify the name of the file for that. 

We also gain the messages in the log after testthat, and the report on how many tests where skipped.
![image](https://user-images.githubusercontent.com/6791940/56785985-97085700-67f7-11e9-8293-ae08bc22daca.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rlesur/crrri/50)
<!-- Reviewable:end -->
