### PR TITLE
add setup and teardown to testthat for opening and closing chrome 

### DIFF
--- a/tests/testthat/test-cdpsession.R
+++ b/tests/testthat/test-cdpsession.R
@@ -2,7 +2,13 @@ context("test-cdpsession")
 
 skip_if_not_chrome()
 
-chrome <- Chrome$new()
+setup(chrome <<- Chrome$new())
+teardown({
+  if (chrome$is_alive()) {
+    message("closing chrome")
+    chrome$close()
+  }
+})
 
 test_that("connect and disconnect methods return promises", {
   client_pr <- CDPSession()
@@ -18,5 +24,3 @@ test_that("CDPSession is disconnected when removed", {
   client <- hold(CDPSession())
   expect_message(client$.__enclos_env__$private$finalize())
 })
-
-chrome$close()

--- a/tests/testthat/test-cdpsession.R
+++ b/tests/testthat/test-cdpsession.R
@@ -2,12 +2,15 @@ context("test-cdpsession")
 
 skip_if_not_chrome()
 
-setup(chrome <<- Chrome$new())
+setup({
+  rlang::env_bind(rlang::global_env(), chrome = Chrome$new())
+})
 teardown({
   if (chrome$is_alive()) {
     message("closing chrome")
     chrome$close()
   }
+  rlang::env_unbind(rlang::global_env(), nms = "chrome")
 })
 
 test_that("connect and disconnect methods return promises", {

--- a/tests/testthat/test-chrome.R
+++ b/tests/testthat/test-chrome.R
@@ -2,12 +2,15 @@ context("test-chrome")
 
 skip_if_not_chrome()
 
-setup(chrome <<- Chrome$new())
+setup({
+  rlang::env_bind(rlang::global_env(), chrome = Chrome$new())
+})
 teardown({
   if (chrome$is_alive()) {
     message("closing chrome")
     chrome$close()
   }
+  rlang::env_unbind(rlang::global_env(), nms = "chrome")
 })
 
 test_that("is_alive() returns a logical", {

--- a/tests/testthat/test-chrome.R
+++ b/tests/testthat/test-chrome.R
@@ -2,7 +2,13 @@ context("test-chrome")
 
 skip_if_not_chrome()
 
-chrome <- Chrome$new()
+setup(chrome <<- Chrome$new())
+teardown({
+  if (chrome$is_alive()) {
+    message("closing chrome")
+    chrome$close()
+  }
+})
 
 test_that("is_alive() returns a logical", {
   expect_is(chrome$is_alive(), "logical")


### PR DESCRIPTION
This is a small improvement trying to use the mechanism from testthat. 

`setup` and `teardown` are in testthat to execute code before each files and at the end of each files. like `on.exit` or `reg.finalizer`. 
There is a mechanism for them to leave in their own `setup-*` and `teardown-*` files, executed before and after each test, but not run by `load_all`, (whereas similar `helper-*` files are run with `load_all`. 

Here, as all the test file does not require chrome, we can't use the files feature. 
`setup` is not really useful, because code is executed imediately, in a clean environment. We must assign to global env... so not sure it is useful. 
However, `teardown` is a way for us to be sure to close connection by writing such code, just after we open, like a `on.exit` call you write just under file creation to be sure the file is deleted at the end. 

I don't remove the object in teardown, because I believe each file is run in its own session but I am not sure... Removing with `rm` throws an error... Still investigating. 

What do you think ? 

Yeah, I know... Small things but I like to test new features! 😄

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rlesur/crrri/53)
<!-- Reviewable:end -->
