### PR TITLE
use promise_map

### DIFF
--- a/R/Chrome.R
+++ b/R/Chrome.R
@@ -86,19 +86,26 @@ chrome_execute <- function(
   # initialize objects
   timeouts <- rep_len(timeouts, length(funs))
   total_timeout <- sum(timeouts) + cleaning_timeout
-  results <- vector("list", length(funs))
-  curr_env <- rlang::current_env()
-  execute_fun <- function(client, index, env) {
+  # results <- vector("list", length(funs))
+  # curr_env <- rlang::current_env()
+  # execute_fun <- function(client, index, env) {
+  #   fun <- purrr::pluck(funs, index)
+  #   delay <- purrr::pluck(timeouts, index)
+  #   result_saved <- promises::then(fun(client), onFulfilled = function(value) {
+  #     if(!is.null(value)) {
+  #       results <- rlang::env_get(env = env, nm = "results")
+  #       rlang::env_bind(env, results = purrr::assign_in(results, index, value))
+  #     }
+  #     client
+  #   })
+
+  # associate a function with its timeout
+  execute_fun <- function(index, client) {
     fun <- purrr::pluck(funs, index)
     delay <- purrr::pluck(timeouts, index)
-    result_saved <- promises::then(fun(client), onFulfilled = function(value) {
-      if(!is.null(value)) {
-        results <- rlang::env_get(env = env, nm = "results")
-        rlang::env_bind(env, results = purrr::assign_in(results, index, value))
-      }
-      client
-    })
-    timeout(result_saved, delay = delay)
+    timeout(fun(client),
+            delay = delay,
+            msg = paste0("The delay of ", delay, " seconds expired in async function n-", index, ".\n"))
   }
 
   # launch Chrome
@@ -106,18 +113,22 @@ chrome_execute <- function(
     bin = bin, debug_port = debug_port, local = local, extra_args = extra_args,
     headless = headless, retry_delay = retry_delay, max_attempts = max_attempts
   )
+  # connect to client
   client <- chrome$connect()
-  all_funs_executed <- promises::promise_reduce(
-    seq_along(funs), execute_fun, env = curr_env, .init = client
+  # all_funs_executed <- promises::promise_reduce(
+  #   seq_along(funs), execute_fun, env = curr_env, .init = client
+  # )
+  results_available <- promises::promise_map(
+    seq_along(funs), execute_fun, client = client
   )
-  results_available <-
-    promises::then(all_funs_executed, onFulfilled = function(value, env = curr_env) {
-      results <- rlang::env_get(env, "results")
-      if(length(results) == 1L) {
-        results <- results[[1]]
-      }
-      results
-    })
+  # results_available <-
+  #   promises::then(all_funs_executed, onFulfilled = function(value, env = curr_env) {
+  #     results <- rlang::env_get(env, "results")
+  #     if(length(results) == 1L) {
+  #       results <- results[[1]]
+  #     }
+  #     results
+  #   })
 
   results_after_cleaning <- promises::finally(results_available, onFinally = function() {
     # it seems that using hold(), i.e. later::run_now() in finally is not a problem

--- a/R/Chrome.R
+++ b/R/Chrome.R
@@ -99,15 +99,6 @@ chrome_execute <- function(
   #     client
   #   })
 
-  # associate a function with its timeout
-  execute_fun <- function(index, client) {
-    fun <- purrr::pluck(funs, index)
-    delay <- purrr::pluck(timeouts, index)
-    timeout(fun(client),
-            delay = delay,
-            msg = paste0("The delay of ", delay, " seconds expired in async function n-", index, ".\n"))
-  }
-
   # launch Chrome
   chrome <- Chrome$new(
     bin = bin, debug_port = debug_port, local = local, extra_args = extra_args,
@@ -115,20 +106,37 @@ chrome_execute <- function(
   )
   # connect to client
   client <- chrome$connect()
+
+  # associate a function with its timeout
+  execute_fun <- function(index) {
+    fun <- purrr::pluck(funs, index)
+    delay <- purrr::pluck(timeouts, index)
+    res <- promises::then(client, function(value) {
+      res <- (fun)(value)
+      # fun must be an async function, i.e. a function that returns a promise
+      if(!promises::is.promising(res)) {
+        stop(paste0("Function n-", index, " passed to chrome_execute does not return a promise."))
+      }
+      res
+    })
+    timeout(res,
+            delay = delay,
+            msg = paste0("The delay of ", delay, " seconds expired in async function n-", index, ".\n"))
+  }
+
   # all_funs_executed <- promises::promise_reduce(
   #   seq_along(funs), execute_fun, env = curr_env, .init = client
   # )
-  results_available <- promises::promise_map(
-    seq_along(funs), execute_fun, client = client
+  all_funs_executed <- promises::promise_map(
+    seq_along(funs), execute_fun
   )
-  # results_available <-
-  #   promises::then(all_funs_executed, onFulfilled = function(value, env = curr_env) {
-  #     results <- rlang::env_get(env, "results")
-  #     if(length(results) == 1L) {
-  #       results <- results[[1]]
-  #     }
-  #     results
-  #   })
+  results_available <-
+    promises::then(all_funs_executed, onFulfilled = function(value) {
+      if(length(value) == 1L) {
+        value <- value[[1]]
+      }
+      value
+    })
 
   results_after_cleaning <- promises::finally(results_available, onFinally = function() {
     # it seems that using hold(), i.e. later::run_now() in finally is not a problem

--- a/R/Chrome.R
+++ b/R/Chrome.R
@@ -86,18 +86,6 @@ chrome_execute <- function(
   # initialize objects
   timeouts <- rep_len(timeouts, length(funs))
   total_timeout <- sum(timeouts) + cleaning_timeout
-  # results <- vector("list", length(funs))
-  # curr_env <- rlang::current_env()
-  # execute_fun <- function(client, index, env) {
-  #   fun <- purrr::pluck(funs, index)
-  #   delay <- purrr::pluck(timeouts, index)
-  #   result_saved <- promises::then(fun(client), onFulfilled = function(value) {
-  #     if(!is.null(value)) {
-  #       results <- rlang::env_get(env = env, nm = "results")
-  #       rlang::env_bind(env, results = purrr::assign_in(results, index, value))
-  #     }
-  #     client
-  #   })
 
   # launch Chrome
   chrome <- Chrome$new(
@@ -124,25 +112,24 @@ chrome_execute <- function(
             msg = paste0("The delay of ", delay, " seconds expired in async function n-", index, ".\n"))
   }
 
-  # all_funs_executed <- promises::promise_reduce(
-  #   seq_along(funs), execute_fun, env = curr_env, .init = client
-  # )
-  all_funs_executed <- promises::promise_map(
-    seq_along(funs), execute_fun
-  )
-  results_available <-
-    promises::then(all_funs_executed, onFulfilled = function(value) {
+  all_funs_executed <- promises::promise_map(seq_along(funs), execute_fun)
+
+  # if only one fun applied, returns the element inside the length 1 list
+  results_available <- promises::then(
+    all_funs_executed,
+    onFulfilled = function(value) {
       if(length(value) == 1L) {
         value <- value[[1]]
       }
       value
-    })
+    }
+  )
 
   results_after_cleaning <- promises::finally(results_available, onFinally = function() {
     # it seems that using hold(), i.e. later::run_now() in finally is not a problem
     # FMPOV, this seems completely weird, but it works well
     chrome$close(async = FALSE)
-    })
+  })
 
   promises::catch(results_after_cleaning, onRejected = function(err) {
     warning(err$message, call. = FALSE)

--- a/tests/testthat/test-chrome.R
+++ b/tests/testthat/test-chrome.R
@@ -146,7 +146,7 @@ test_that("timeouts are respected and recycled (using JS in chrome)", {
     }
   }
   async_funs <- list(
-    async_fun(1000),
+    async_fun(500),
     async_fun(3000)
   )
   expect_error(chrome_execute(.list = async_funs, timeouts = c(30, 1)),

--- a/tests/testthat/test-chrome.R
+++ b/tests/testthat/test-chrome.R
@@ -139,3 +139,8 @@ test_that("timeouts are respected and recycle", {
   expect_error(chrome_execute(.list = async_funs, timeouts = c(1)),
                "The delay of 1 seconds expired in async function n-2.")
 })
+
+test_that("funs must be async functions", {
+  fun <- function(client) 1
+  expect_error(chrome_execute(fun))
+})

--- a/tests/testthat/test-chrome.R
+++ b/tests/testthat/test-chrome.R
@@ -107,7 +107,9 @@ test_that("With only 1 argument chrome_execute() returns the value of the async 
   # if not async, return invisibly
   expect_invisible(chrome_execute(async_fun, async = FALSE))
   # if async, result is a promise
-  expect_s3_class(chrome_execute(async_fun, async = TRUE), "promise")
+  pr <- chrome_execute(async_fun, async = TRUE)
+  expect_s3_class(pr, "promise")
+  hold(pr)
 })
 
 


### PR DESCRIPTION
This is WIP on using `promise_map` to simplify `chrome_execute` during review of #62 

its a merge request onto `chrome-do` branch

some things are not working when closing chrome, I get asio error
```
[2019-05-05 17:19:12] [info] Error getting remote endpoint: asio.system:10009 (Le descripteur de fichier fourni n’est pas valide.)
[2019-05-05 17:19:12] [info] asio async_shutdown error: asio.system:10009 (Le descripteur de fichier fourni n’est pas valide.)
[2019-05-05 17:19:12] [error] handle_connect error: Timer Expired
```

still investigating

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rlesur/crrri/64)
<!-- Reviewable:end -->
