### PR TITLE
use rlang env funs that are clearer

### DIFF
--- a/R/CDProtocol.R
+++ b/R/CDProtocol.R
@@ -11,7 +11,7 @@ CDProtocol <- R6::R6Class(
       private$.protocol <- protocol
     },
     domain_description = function(domain) {
-      desc <- get(domain, private$.protocol$domains)$description
+      desc <- rlang::env_get(env = private$.protocol$domains, nm = domain)$description
       if(is.null(desc)) {
         desc <- ""
       }
@@ -79,7 +79,7 @@ CDProtocol <- R6::R6Class(
   private = list(
     .protocol = "environment",
     .list_objects = function(domain, cl) {
-      specs <- get(domain, private$.protocol$domains)[[cl]]
+      specs <- rlang::env_get(env = private$.protocol$domains, nm = domain)[[cl]]
       if(is.null(specs)) return(list())
       obj_names <- ls(specs)
       l <- as.list(paste(domain, obj_names, sep = "."))

--- a/R/domain.R
+++ b/R/domain.R
@@ -49,6 +49,10 @@ Domain <- R6::R6Class(
   private = list(
     .domain_name = NULL,
     .build_command = function(method_to_be_sent, name) {
+      # environment of the current fonction to get
+      # `method_to_be_sent` when needed
+      fn_env <- rlang::current_env()
+
       fun <- function() {
         params_to_be_sent <-
           rlang::fn_fmls_names() %>% # pick the fun arguments
@@ -59,12 +63,11 @@ Domain <- R6::R6Class(
         if(!is.null(callback)) {
           callback <- rlang::as_function(callback)
         }
-
+        # since the function parameters are not controlled,
+        # there might be some conflicts between CDP parameters and `method_to_be_sent`
+        # Therefore, we use env_get() to retrieve the correct `method_to_be_sent`
         self$.__client__$send(
-            # since the function parameters are not controlled,
-            # there might be some conflicts between CDP parameters and `method_to_be_sent`
-            # Therefore, use get() to retrieve the `method_to_be_sent`
-            get("method_to_be_sent", envir = parent.env(environment())),
+            rlang::env_get(env = fn_env, nm = "method_to_be_sent"),
             params = params_to_be_sent,
             onresponse = callback
           )


### PR DESCRIPTION
or at least seems to be

Just because it will close #44 

I did not modify the stuff like 
```r
private$.protocol$domains[[domain]]$commands[[command]]$parameters
```

because this works and is pretty clear to understand. Don't know if there is a risk of error. I don't think so. 

This PR is not really important. We could keep as is and just close both PR and issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rlesur/crrri/70)
<!-- Reviewable:end -->
