### PR TITLE
use a integerish to have a less strict test on port and max attempts

### DIFF
--- a/R/CDPRemote.R
+++ b/R/CDPRemote.R
@@ -26,7 +26,7 @@ NULL
 #' * `remote`: an object representing a remote application implementing the
 #'     Chrome Debugging Protocol.
 #' * `host`: Character scalar, the host name of the application.
-#' * `debug_port`: Numeric scalar, the remote debugging port.
+#' * `debug_port`: Integer scalar, the remote debugging port.
 #' * `secure`: Logical scalar, indicating whether the https/wss protocols
 #'     shall be used for connecting to the remote application.
 #' * `local`: Logical scalar, indicating whether the local version of the
@@ -34,7 +34,7 @@ NULL
 #'     fetched _remotely_.
 #' * `retry_delay`: Number, delay in seconds between two successive tries to
 #'     connect to the remote application.
-#' * `max_attempts`: Logical scalar, number of tries to connect to headless
+#' * `max_attempts`: Integer scalar, number of tries to connect to headless
 #'     Chromium/Chrome.
 #' * `callback`: Function with one argument.
 #'
@@ -114,7 +114,7 @@ CDPRemote <- R6::R6Class(
       assert_that(is.scalar(secure), is.logical(secure))
       assert_that(is.scalar(local), is.logical(local))
       assert_that(is.number(retry_delay))
-      assert_that(is_scalar_integer(max_attempts))
+      assert_that(is_scalar_integerish(max_attempts))
 
       private$.port <- debug_port
       private$.secure <- secure

--- a/R/Chrome.R
+++ b/R/Chrome.R
@@ -415,7 +415,7 @@ chr_launch <- function(
         bin,
         chrome_args,
         echo_cmd = TRUE,
-        supervise = FALSE
+        supervise = TRUE
       ),
       error = function(e) NULL
     )

--- a/R/Chrome.R
+++ b/R/Chrome.R
@@ -184,7 +184,7 @@ perform_with_chrome <- function(
 #'     in headless mode.
 #' * `retry_delay`: Number, delay in seconds between two successive tries to
 #'     connect to headless Chromium/Chrome.
-#' * `max_attempts`: Logical scalar, number of tries to connect to headless
+#' * `max_attempts`: Integer scalar, number of tries to connect to headless
 #'     Chromium/Chrome.
 #' * `callback`: Function with one argument.
 #' * `async`: Does the function return a promise?
@@ -270,14 +270,14 @@ Chrome <- R6::R6Class(
     ) {
       assert_that(is_scalar_character(bin))
       assert_that(
-        is_scalar_integer(debug_port),
+        is_scalar_integerish(debug_port),
         is_user_port(debug_port),
         is_available_port(debug_port)
       )
       assert_that(is.scalar(local), is.logical(local))
       assert_that(is.scalar(headless), is.logical(headless))
       assert_that(is.number(retry_delay))
-      assert_that(is_scalar_integer(max_attempts))
+      assert_that(is_scalar_integerish(max_attempts))
 
       private$.bin <- bin
       work_dir <- chr_new_data_dir()
@@ -415,7 +415,7 @@ chr_launch <- function(
         bin,
         chrome_args,
         echo_cmd = TRUE,
-        supervise = TRUE
+        supervise = FALSE
       ),
       error = function(e) NULL
     )

--- a/R/utils.R
+++ b/R/utils.R
@@ -8,11 +8,11 @@ assertthat::on_failure(is_scalar_character) <- function(call, env) {
   paste0(deparse(call$x), " is not a character scalar (a length one character vector).")
 }
 
-is_scalar_integer <- function(x) {
-  rlang::is_scalar_integer(x)
+is_scalar_integerish <- function(x) {
+  rlang::is_scalar_integerish(x)
 }
 
-assertthat::on_failure(is_scalar_integer) <- function(call, env) {
+assertthat::on_failure(is_scalar_integerish) <- function(call, env) {
   paste0(deparse(call$x), " is not an integer scalar (a length one integer vector).")
 }
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -164,3 +164,11 @@ test_that("stop_or_reject handles async", {
   expect_error(stop_or_reject("error", FALSE), "^error$")
   expect_error(hold(stop_or_reject("error", TRUE)), "^error$")
 })
+
+test_that("check integerish accepts integer without L but not double", {
+  expect_true(is_scalar_integerish(10))
+  expect_true(is_scalar_integerish(10L))
+  expect_false(is_scalar_integerish(10.5))
+})
+
+


### PR DESCRIPTION
closes #82

this allows `9233` or `9233L` to work but not `9233.5`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rlesur/crrri/83)
<!-- Reviewable:end -->
