### PR TITLE
Allow to run client without RStudio Viewer

### DIFF
--- a/R/CDPSession.R
+++ b/R/CDPSession.R
@@ -142,9 +142,11 @@ CDPSession <- function(
   # if the target is a page, add methods inspect(), activateTab() and closeTab()
   # these methods are added dynamically because they are irrelevant for the "browser" websocket endpoint
   if(identical(target_type, "page")) {
-    CDPSession$set("public", "inspect", function() {
+    CDPSession$set("public", "inspect", function(viewer) {
       if(self$readyState() == 1L) {
-        inspect_target(private$.host, private$.port, private$.secure, private$.target_id)
+        if (viewer){
+          inspect_target(private$.host, private$.port, private$.secure, private$.target_id)
+        }
       } else {
         warning(
           "Invalid connection state. Cannot open target in a web browser.",

--- a/README.Rmd
+++ b/README.Rmd
@@ -47,8 +47,15 @@ set correctly by executing `Sys.getenv("HEADLESS_CHROME")` in your R console.
 
 Otherwise, you can use the `bin` argument of the `Chrome` class `new()`
 method to provide the path directly.
+
 ```r
 chrome <- Chrome$new(bin = "<path-to-chrome-binary->")
+```
+
+Note that if ever you don't know where your binary is, you can use the `find_chrome()` function from [`{pagedown}`](https://github.com/rstudio/pagedown), which will try to guess where your binary is (You might neeed to install it).
+
+```r
+chrome <- Chrome$new(bin = pagedown::find_chrome())
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ method to provide the path directly.
 chrome <- Chrome$new(bin = "<path-to-chrome-binary->")
 ```
 
+Note that if ever you don’t know where your binary is, you can use the
+`find_chrome()` function from
+[`{pagedown}`](https://github.com/rstudio/pagedown), which will try to
+guess where your binary is (You might neeed to install it).
+
+``` r
+chrome <- Chrome$new(bin = pagedown::find_chrome())
+```
+
 ## Installation
 
 You can install the development version of `crrri` from GitHub with:
@@ -159,7 +168,8 @@ comes from the fact that the `Page$navigate()` function is also
 asynchronous. All the asynchronous methods possess a `callback`
 argument. When the R session receives the result of the command from
 Chrome, R executes this callback function passing the result object to
-this function. For instance, you can execute:
+this function. For instance, you can
+execute:
 
 ``` r
 Page$navigate(url = "https://ropensci.org/", callback = function(result) {


### PR DESCRIPTION
Especially when running `chrome` in non headless mode, we get the Viewer + the browser:

![Screenshot 2019-10-10 at 14 43 55](https://user-images.githubusercontent.com/17936236/66569710-6d0bdc80-eb6c-11e9-867d-ef0a45a502c3.png)

This PR allows to get the client without opening the Viewer: 

``` r 
library(crrri)
chrome <- Chrome$new(
  pagedown::find_chrome(),
  debug_port = 12358L, 
  headless = FALSE
)
client <- chrome$connect(callback = function(client) {
  client$inspect(viewer = FALSE)
})

Page <- client$Page
Runtime <- client$Runtime
Page$navigate(url = "http://google.com")

chrome$close()
```

![Screenshot 2019-10-10 at 14 46 17](https://user-images.githubusercontent.com/17936236/66569891-bf4cfd80-eb6c-11e9-9931-5c96769a8fa2.png)


Might also be useful when using `{crrri}` as a tool for testing web app.