### PR TITLE
add support for a custom user data dir

### DIFF
--- a/tests/testthat/helper-chrome.R
+++ b/tests/testthat/helper-chrome.R
@@ -26,3 +26,10 @@ setup_chrome_test <- function(env = rlang::caller_env()) {
   # we need this because these function are normally called in the test file directly
   env = env)
 }
+
+without_verbose <- function(code) {
+  old <- getOption("crrri.verbose", TRUE)
+  options(crrri.verbose = FALSE)
+  on.exit(options(crrri.verbose = old))
+  force(code)
+}


### PR DESCRIPTION
This will close #90 

Current implementation is using a new argument in `Chrome$new()`. 

Another choice would be to detect if a `--user-data-dir` is passed in `extra_args` and deactivate the creation of new work dir by crrri. Would be oriented toward a more advanced usage. 

If provided in `user_data_dir`, the folder won't be deleted by crrri at the end. A message warn the user (but is inside a promise so print in a weirdly timing)

@yonicd, using this PR will help to test with a custom user data dir.

@RLesur what do you think ? Should we test and improve some usage ?

I know it works well in headful mode, but not sure to check in headless mode as `chrome://version` url does not work in headless mode.